### PR TITLE
Middleware, better argument resolution, better errors

### DIFF
--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -50,3 +50,14 @@ Set the headers returned by `JsonRoutes.sendResult`. Default value is:
   "Pragma": "no-cache"
 }
 ```
+
+## MiddleWare
+
+If you want to insert connect middleware and ensure that it runs before your REST route is hit, use `JsonRoutes.middleWare`.
+
+```js
+JsonRoutes.middleWare.use(function (req, res, next) {
+  console.log(req.body);
+  next();
+});
+```

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -7,6 +7,9 @@ JsonRoutes = {};
 WebApp.rawConnectHandlers.use(connect.bodyParser());
 WebApp.rawConnectHandlers.use(connect.query());
 
+JsonRoutes.middleWare = connect();
+WebApp.rawConnectHandlers.use(JsonRoutes.middleWare);
+
 // List of all defined JSON API endpoints
 JsonRoutes.routes = [];
 

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -97,6 +97,8 @@ Then you can call this method with:
 POST /return-five
 ```
 
+You can optionally pass a `getArgsFromRequest` option set to a function that accepts the `request` object and uses it to return the arguments array for your method. By default, simple:rest expects that the request body is a JSON array that maps to the method arguments, or a single JSON object that is passed as the only argument to the method.
+
 ### Collection methods
 
 The default Meteor collection methods (insert, update, and remove) are also automatically exposed when this package is added. 


### PR DESCRIPTION
1. Added `JsonRoutes.middleWare` that can be used to attach middleware in the appropriate place
2. Pass through options, allowing `getArgsFromRequest` to be customized per method
3. Use `error.sanitizedError` as response error if present
4. Use `error.error` as the response code instead of 500 if it's a number
5. Related documentation updates and delint code in a few places

@stubailo I'm also curious why JsonRoutes uses `rawConnectHandlers` instead of `connectHandlers`? It seemed to work with either in my testing, and using the documented API makes more sense to me because then any middleware packages I add before this one will work properly. (I created an XML-to-JSON middleware package because unfortunately I have to consume XML, but it only works if added to `rawConnectHandlers`, same on that JsonRoutes uses.)