### PR TITLE
Better error responses

### DIFF
--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -36,19 +36,31 @@ Return data fom a route.
 
 - `response` - the Node response object you got as an argument to your handler
 function.
-- `code` - the status code to send. `200` for OK, `500` for internal error, etc.
-- `data` - the data you want to send back, will be sent as serialized JSON with
-content type `application/json`.
+- `code` - the status code to send. `200` for OK, `500` for internal error, etc. If the `data` argument is an `Error` type, this is overwritten based on the error.
+- `data` - the data you want to send back. This is serialized to JSON with
+content type `application/json`. If `undefined`, there will be no response body. If an `Error` type, a JSON representation of the error details will be sent.
 
 ### JsonRoutes.setResponseHeaders(headerObj)
 
-Set the headers returned by `JsonRoutes.sendResult`. Default value is:
+Set the headers used by `JsonRoutes.sendResult` for the response. Default value is:
 
 ```js
 {
   "Cache-Control": "no-store",
   "Pragma": "no-cache"
 }
+```
+
+### JsonRoutes.config(configObj)
+
+Configure global JsonRoutes options. Currently only one option is supported:
+
+```js
+JsonRoutes.config({
+  // By default, responses are pretty printed in development environments only.
+  // Set this to `true` to pretty print always.
+  prettyPrintResponses: true
+});
 ```
 
 ## Adding middlewares
@@ -63,6 +75,11 @@ JsonRoutes.middleWare.use(function (req, res, next) {
 ```
 
 ## Change log
+
+#### vNext
+
+- Add ability for `data` argument of `sendResult` to be an `Error`
+- Add `JsonRoutes.config` and ability to force pretty printing of all responses
 
 #### 1.0.3
 

--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -67,6 +67,7 @@ JsonRoutes.middleWare.use(function (req, res, next) {
 #### vNext
 
 - Add ability for `data` argument of `sendResult` to be an `Error`
+- Catch handler errors and automatically send a response. Look for `statusCode` and `jsonResponse` properties on thrown errors.
 
 #### 1.0.3
 

--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -51,18 +51,6 @@ Set the headers used by `JsonRoutes.sendResult` for the response. Default value 
 }
 ```
 
-### JsonRoutes.config(configObj)
-
-Configure global JsonRoutes options. Currently only one option is supported:
-
-```js
-JsonRoutes.config({
-  // By default, responses are pretty printed in development environments only.
-  // Set this to `true` to pretty print always.
-  prettyPrintResponses: true
-});
-```
-
 ## Adding middlewares
 
 If you want to insert connect middleware and ensure that it runs before your REST route is hit, use `JsonRoutes.middleWare`.
@@ -79,7 +67,6 @@ JsonRoutes.middleWare.use(function (req, res, next) {
 #### vNext
 
 - Add ability for `data` argument of `sendResult` to be an `Error`
-- Add `JsonRoutes.config` and ability to force pretty printing of all responses
 
 #### 1.0.3
 

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -55,15 +55,6 @@ var setHeaders = function (res) {
   });
 };
 
-var defaultConfig = {
-  prettyPrintResponses: false
-};
-
-var config = defaultConfig;
-JsonRoutes.config = function (userConfig) {
-  config = _.extend({}, defaultConfig, userConfig);
-};
-
 // Convert `Error` objects to JSON representations
 JsonRoutes._errorToJson = function (json) {
   if (!json) {
@@ -93,7 +84,7 @@ JsonRoutes._errorToJson = function (json) {
 };
 
 /**
- * Sets the response headers, status code, and body, and ends it. The JSON response will be pretty printed if NODE_ENV is `development` or if you have configured `prettyPrintResponses: true`.
+ * Sets the response headers, status code, and body, and ends it. The JSON response will be pretty printed if NODE_ENV is `development`.
  * @param {Object}   res  Response object
  * @param {Number}   code HTTP status code. If `json` argument is an `Error` object, this will be overwritten based on the error.
  * @param {Object|Array|null|undefined|Error} json The object to stringify as the response. If `null`, the response will be "null". If `undefined`, there will be no response body. If an `Error` type, a JSON representation of the error details will be sent.
@@ -118,7 +109,7 @@ JsonRoutes.sendResult = function (res, code, json) {
 
   // Set response body
   if (json !== undefined) {
-    var shouldPrettyPrint = (config.prettyPrintResponses || process.env.NODE_ENV === 'development');
+    var shouldPrettyPrint = (process.env.NODE_ENV === 'development');
     var spacer = shouldPrettyPrint ? 2 : null;
     res.setHeader("Content-type", "application/json");
     res.write(JSON.stringify(json, null, spacer));

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -35,7 +35,11 @@ JsonRoutes.add = function (method, path, handler) {
 
   connectRouter[method](path, function (req, res, next) {
     Fiber(function () {
-      handler(req, res, next);
+      try {
+        handler(req, res, next);
+      } catch (err) {
+        JsonRoutes.sendResult(res, null, err);
+      }
     }).run();
   });
 };
@@ -56,56 +60,73 @@ var setHeaders = function (res) {
 };
 
 // Convert `Error` objects to JSON representations
-JsonRoutes._errorToJson = function (json) {
-  if (!json) {
-    return json;
+JsonRoutes._errorToJson = function (data) {
+  if (!data) {
+    return data;
   }
 
-  if (json instanceof Meteor.Error) {
-    json = {
-      error: json.error,
-      reason: json.reason,
-      details: json.details
+  // If an error has a `jsonResponse` property, we
+  // send that. This allows packages to check whether
+  // JsonRoutes package is used and if so, to include
+  // a specific error response body with the errors they throw.
+  if (data instanceof Meteor.Error) {
+    return data.jsonResponse || {
+      error: data.error,
+      reason: data.reason,
+      details: data.details
     };
-  } else if (json.sanitizedError instanceof Meteor.Error) {
-    json = {
-      error: json.sanitizedError.error,
-      reason: json.sanitizedError.reason,
-      details: json.sanitizedError.details
+  } else if (data.sanitizedError instanceof Meteor.Error) {
+    return data.sanitizedError.jsonResponse || {
+      error: data.sanitizedError.error,
+      reason: data.sanitizedError.reason,
+      details: data.sanitizedError.details
     };
-  } else if (json instanceof Error) {
-    json = {
+  } else if (data instanceof Error) {
+    return data.jsonResponse || {
       error: "internal-server-error",
       reason: "Internal server error"
     };
   }
 
-  return json;
+  // Data was not an error
+  return data;
+};
+
+var setStatusCode = function (res, code, data) {
+  if (!data) {
+    res.statusCode = code || 200;
+    return;
+  }
+
+  // If an error has a `statusCode` property, we
+  // use that. This allows packages to check whether
+  // JsonRoutes package is used and if so, to include
+  // a specific error status code with the errors they throw.
+  if (data instanceof Meteor.Error) {
+    res.statusCode = data.statusCode || 400;
+  } else if (data.sanitizedError instanceof Meteor.Error) {
+    res.statusCode = data.sanitizedError.statusCode || data.statusCode || 400;
+  } else if (data instanceof Error) {
+    res.statusCode = data.statusCode || 500;
+  } else {
+    res.statusCode = code || 200;
+  }
 };
 
 /**
  * Sets the response headers, status code, and body, and ends it. The JSON response will be pretty printed if NODE_ENV is `development`.
  * @param {Object}   res  Response object
  * @param {Number}   code HTTP status code. If `json` argument is an `Error` object, this will be overwritten based on the error.
- * @param {Object|Array|null|undefined|Error} json The object to stringify as the response. If `null`, the response will be "null". If `undefined`, there will be no response body. If an `Error` type, a JSON representation of the error details will be sent.
+ * @param {Object|Array|null|undefined|Error} data The object to stringify as the response. If `null`, the response will be "null". If `undefined`, there will be no response body. If an `Error` type, a JSON representation of the error details will be sent.
  */
-JsonRoutes.sendResult = function (res, code, json) {
+JsonRoutes.sendResult = function (res, code, data) {
+  // Set headers on response
   setHeaders(res);
+  // Set status code on response
+  setStatusCode(res, code, data);
 
   // Convert `Error` objects to JSON representations
-  json = JsonRoutes._errorToJson(json);
-
-  // Override code for errors
-  if (json && json.error) {
-    if (json.error === "internal-server-error") {
-      code = 500;
-    } else {
-      code = _.isNumber(json.error) ? json.error : 400;
-    }
-  }
-
-  // Set status code on response
-  res.statusCode = code;
+  var json = JsonRoutes._errorToJson(data);
 
   // Set response body
   if (json !== undefined) {

--- a/packages/rest-accounts-password/rest-login.js
+++ b/packages/rest-accounts-password/rest-login.js
@@ -54,10 +54,8 @@ JsonRoutes.add("post", "/users/login", function (req, res) {
       tokenExpires: tokenExpiration
     });
   } catch (err) {
-    var errJson = convertErrorToJson(err);
     console.log("Error in login: ", err);
-
-    JsonRoutes.sendResult(res, 500, errJson);
+    JsonRoutes.sendResult(res, null, err);
   }
 });
 
@@ -98,30 +96,7 @@ JsonRoutes.add("post", "/users/register", function (req, res) {
       id: userId
     });
   } catch (err) {
-    var errJson = convertErrorToJson(err);
     console.log("Error in registration: ", err);
-
-    JsonRoutes.sendResult(res, 500, errJson);
+    JsonRoutes.sendResult(res, null, err);
   }
 });
-
-// Just like in DDP, send a sanitized error over HTTP
-function convertErrorToJson(err) {
-  if (err.sanitizedError) {
-    var sE = err.sanitizedError;
-    return {
-      error: sE.error,
-      reason: sE.reason
-    };
-  } else if (err.errorType === "Meteor.Error") {
-    return {
-      error: err.error,
-      reason: err.reason
-    };
-  } else {
-    return {
-      error: "internal-server-error",
-      reason: "Internal server error."
-    };
-  }
-}

--- a/packages/rest-accounts-password/rest-login.js
+++ b/packages/rest-accounts-password/rest-login.js
@@ -5,58 +5,53 @@ JsonRoutes.add("options", "/users/login", function (req, res) {
 JsonRoutes.add("post", "/users/login", function (req, res) {
   var options = req.body;
 
-  try {
-    check(options, {
-      email: Match.Optional(String),
-      username: Match.Optional(String),
-      password: String
-    });
+  check(options, {
+    email: Match.Optional(String),
+    username: Match.Optional(String),
+    password: String
+  });
 
-    // Look up a user that has the username passed in, or has an email with the
-    // given address in their emails array. (Note that "email.address" is querying
-    // an array field)
-    var user = Meteor.users.findOne({
-      $or: [
-        { username: options.username },
-        { "emails.address": options.email }
-      ]
-    });
+  // Look up a user that has the username passed in, or has an email with the
+  // given address in their emails array. (Note that "email.address" is querying
+  // an array field)
+  var user = Meteor.users.findOne({
+    $or: [
+      { username: options.username },
+      { "emails.address": options.email }
+    ]
+  });
 
-    if (! user) {
-      throw new Meteor.Error("not-found",
-        "User with that username or email address not found.");
-    }
-
-    var result = Accounts._checkPassword(user, options.password);
-    check(result, {
-      userId: String,
-      error: Match.Optional(Meteor.Error)
-    });
-
-    if (result.error) {
-      throw result.error;
-    }
-
-    var stampedLoginToken = Accounts._generateStampedLoginToken();
-    check(stampedLoginToken, {
-      token: String,
-      when: Date
-    });
-
-    Accounts._insertLoginToken(result.userId, stampedLoginToken);
-
-    var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
-    check(tokenExpiration, Date);
-
-    JsonRoutes.sendResult(res, 200, {
-      id: result.userId,
-      token: stampedLoginToken.token,
-      tokenExpires: tokenExpiration
-    });
-  } catch (err) {
-    console.log("Error in login: ", err);
-    JsonRoutes.sendResult(res, null, err);
+  if (! user) {
+    throw new Meteor.Error("not-found",
+      "User with that username or email address not found.");
   }
+
+  var result = Accounts._checkPassword(user, options.password);
+  check(result, {
+    userId: String,
+    error: Match.Optional(Meteor.Error)
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  var stampedLoginToken = Accounts._generateStampedLoginToken();
+  check(stampedLoginToken, {
+    token: String,
+    when: Date
+  });
+
+  Accounts._insertLoginToken(result.userId, stampedLoginToken);
+
+  var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
+  check(tokenExpiration, Date);
+
+  JsonRoutes.sendResult(res, 200, {
+    id: result.userId,
+    token: stampedLoginToken.token,
+    tokenExpires: tokenExpiration
+  });
 });
 
 JsonRoutes.add("options", "/users/register", function (req, res) {
@@ -66,37 +61,32 @@ JsonRoutes.add("options", "/users/register", function (req, res) {
 JsonRoutes.add("post", "/users/register", function (req, res) {
   var options = req.body;
 
-  try {
-    check(options, {
-      username: Match.Optional(String),
-      email: Match.Optional(String),
-      password: String
-    });
+  check(options, {
+    username: Match.Optional(String),
+    email: Match.Optional(String),
+    password: String
+  });
 
-    var userId = Accounts.createUser(
-      _.pick(options, "username", "email", "password"));
+  var userId = Accounts.createUser(
+    _.pick(options, "username", "email", "password"));
 
-    // Log in the new user and send back a token
-    var stampedLoginToken = Accounts._generateStampedLoginToken();
-    check(stampedLoginToken, {
-      token: String,
-      when: Date
-    });
+  // Log in the new user and send back a token
+  var stampedLoginToken = Accounts._generateStampedLoginToken();
+  check(stampedLoginToken, {
+    token: String,
+    when: Date
+  });
 
-    // This adds the token to the user
-    Accounts._insertLoginToken(userId, stampedLoginToken);
+  // This adds the token to the user
+  Accounts._insertLoginToken(userId, stampedLoginToken);
 
-    var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
-    check(tokenExpiration, Date);
+  var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
+  check(tokenExpiration, Date);
 
-    // Return the same things the login method returns
-    JsonRoutes.sendResult(res, 200, {
-      token: stampedLoginToken.token,
-      tokenExpires: tokenExpiration,
-      id: userId
-    });
-  } catch (err) {
-    console.log("Error in registration: ", err);
-    JsonRoutes.sendResult(res, null, err);
-  }
+  // Return the same things the login method returns
+  JsonRoutes.sendResult(res, 200, {
+    token: stampedLoginToken.token,
+    tokenExpires: tokenExpiration,
+    id: userId
+  });
 });

--- a/packages/rest/rest-tests.js
+++ b/packages/rest/rest-tests.js
@@ -87,6 +87,20 @@ if (Meteor.isServer) {
     }
   });
 
+  Meteor.method("throws-error", function () {
+    throw new Error('Bad');
+  });
+
+  Meteor.method("throws-meteor-error", function () {
+    throw new Meteor.Error(400, 'Foo');
+  });
+
+  Meteor.method("throws-sanitized-error", function () {
+    var error = new Error('Bad');
+    error.sanitizedError = new Meteor.Error(400, 'Foo');
+    throw error;
+  });
+
   Meteor.method("add-all-arguments", function (a, b, c) {
     return a + b + c;
   });
@@ -233,6 +247,47 @@ if (Meteor.isServer) {
       }, expect(function (err, res) {
         test.equal(err, null);
         test.equal(res.data, 5);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("calling method with wrong auth", [
+    function (test, expect) {
+      HTTP.post("/methods/return-five-auth", {
+        headers: { Authorization: "Bearer foo" }
+      }, expect(function (err, res) {
+        test.equal(err, null);
+        test.equal(res.data, 0);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-error", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.error, "internal-server-error");
+        test.equal(res.statusCode, 500);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method meteor error", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-meteor-error", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.reason, "Foo");
+        test.equal(res.statusCode, 400);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error with meteor error", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-sanitized-error", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.reason, "Foo");
+        test.equal(res.statusCode, 400);
       }));
     }
   ]);

--- a/packages/rest/rest-tests.js
+++ b/packages/rest/rest-tests.js
@@ -87,6 +87,10 @@ if (Meteor.isServer) {
     }
   });
 
+  Meteor.method("status-code", function () {
+    this.setStatusCode(222);
+  });
+
   Meteor.method("throws-error", function () {
     throw new Error('Bad');
   });
@@ -342,6 +346,15 @@ if (Meteor.isServer) {
         test.isTrue(!!err);
         test.equal(res.data.ding, "dong");
         test.equal(res.statusCode, 499);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method status code", [
+    function (test, expect) {
+      HTTP.post("/methods/status-code", expect(function (err, res) {
+        test.isFalse(!!err);
+        test.equal(res.statusCode, 222);
       }));
     }
   ]);

--- a/packages/rest/rest-tests.js
+++ b/packages/rest/rest-tests.js
@@ -92,12 +92,36 @@ if (Meteor.isServer) {
   });
 
   Meteor.method("throws-meteor-error", function () {
-    throw new Meteor.Error(400, 'Foo');
+    throw new Meteor.Error('foo-bar', 'Foo');
   });
 
   Meteor.method("throws-sanitized-error", function () {
     var error = new Error('Bad');
-    error.sanitizedError = new Meteor.Error(400, 'Foo');
+    error.sanitizedError = new Meteor.Error('foo-bar', 'Foo');
+    throw error;
+  });
+
+  Meteor.method("throws-error-custom", function () {
+    var error = new Error('Bad');
+    error.jsonResponse = {ding: 'dong'};
+    error.statusCode = 499;
+    throw error;
+  });
+
+  Meteor.method("throws-meteor-error-custom", function () {
+    var error = new Meteor.Error('foo-bar', 'Foo');
+    error.jsonResponse = {ding: 'dong'};
+    error.statusCode = 499;
+    throw error;
+  });
+
+  Meteor.method("throws-sanitized-error-custom", function () {
+    var error = new Error('Bad');
+    error.jsonResponse = {ding: 'ding'};
+    error.statusCode = 999;
+    error.sanitizedError = new Meteor.Error('foo-bar', 'Foo');
+    error.sanitizedError.jsonResponse = {ding: 'dong'};
+    error.sanitizedError.statusCode = 499;
     throw error;
   });
 
@@ -288,6 +312,36 @@ if (Meteor.isServer) {
         test.isTrue(!!err);
         test.equal(res.data.reason, "Foo");
         test.equal(res.statusCode, 400);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error custom", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-error-custom", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.ding, "dong");
+        test.equal(res.statusCode, 499);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method meteor error custom", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-meteor-error-custom", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.ding, "dong");
+        test.equal(res.statusCode, 499);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error with meteor error custom", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-sanitized-error-custom", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.ding, "dong");
+        test.equal(res.statusCode, 499);
       }));
     }
   ]);

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -22,37 +22,35 @@ Meteor.publish = function (name, handler, options) {
   });
 
   JsonRoutes.add(httpOptions.httpMethod, httpOptions.url, function (req, res) {
-    catchAndReportErrors(httpOptions.url, res, function () {
-      var userId = getUserIdFromRequest(req);
+    var userId = getUserIdFromRequest(req);
 
-      var httpSubscription = new HttpSubscription({
-        request: req,
-        userId: userId
-      });
-
-      httpSubscription.on("ready", function (response) {
-        JsonRoutes.sendResult(res, 200, response);
-      });
-
-      var handlerArgs = httpOptions.getArgsFromRequest(req);
-
-      var handlerReturn = handler.apply(httpSubscription, handlerArgs);
-
-      // Fast track for publishing cursors - we don't even need livequery here,
-      // just making a normal DB query
-      if (handlerReturn && handlerReturn._publishCursor) {
-        httpPublishCursor(handlerReturn, httpSubscription);
-        httpSubscription.ready();
-      } else if (handlerReturn && _.isArray(handlerReturn)) {
-        // We don't need to run the checks to see if the cursors overlap and stuff
-        // because calling Meteor.publish will do that for us :]
-        _.each(handlerReturn, function (cursor) {
-          httpPublishCursor(cursor, httpSubscription);
-        });
-
-        httpSubscription.ready();
-      }
+    var httpSubscription = new HttpSubscription({
+      request: req,
+      userId: userId
     });
+
+    httpSubscription.on("ready", function (response) {
+      JsonRoutes.sendResult(res, 200, response);
+    });
+
+    var handlerArgs = httpOptions.getArgsFromRequest(req);
+
+    var handlerReturn = handler.apply(httpSubscription, handlerArgs);
+
+    // Fast track for publishing cursors - we don't even need livequery here,
+    // just making a normal DB query
+    if (handlerReturn && handlerReturn._publishCursor) {
+      httpPublishCursor(handlerReturn, httpSubscription);
+      httpSubscription.ready();
+    } else if (handlerReturn && _.isArray(handlerReturn)) {
+      // We don't need to run the checks to see if the cursors overlap and stuff
+      // because calling Meteor.publish will do that for us :]
+      _.each(handlerReturn, function (cursor) {
+        httpPublishCursor(cursor, httpSubscription);
+      });
+
+      httpSubscription.ready();
+    }
   });
 };
 
@@ -135,25 +133,27 @@ function addHTTPMethod(httpMethod, url, handler, options) {
   });
 
   JsonRoutes.add(httpMethod, url, function (req, res) {
-    catchAndReportErrors(url, res, function () {
-      var userId = getUserIdFromRequest(req);
+    var userId = getUserIdFromRequest(req);
+    var statusCode = 200;
 
-      // XXX replace with a real one?
-      var methodInvocation = {
-        userId: userId,
-        setUserId: function () {
-          throw Error("setUserId not implemented in this version of simple:rest");
-        },
-        isSimulation: false,
-        unblock: function () {
-          // no-op
-        }
-      };
+    // XXX replace with a real one?
+    var methodInvocation = {
+      userId: userId,
+      setUserId: function () {
+        throw Error("setUserId not implemented in this version of simple:rest");
+      },
+      isSimulation: false,
+      unblock: function () {
+        // no-op
+      },
+      setStatusCode: function (code) {
+        statusCode = code;
+      }
+    };
 
-      var handlerArgs = options.getArgsFromRequest(req);
-      var handlerReturn = handler.apply(methodInvocation, handlerArgs);
-      JsonRoutes.sendResult(res, 200, handlerReturn);
-    });
+    var handlerArgs = options.getArgsFromRequest(req);
+    var handlerReturn = handler.apply(methodInvocation, handlerArgs);
+    JsonRoutes.sendResult(res, statusCode, handlerReturn);
   });
 }
 

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -240,32 +240,6 @@ function catchAndReportErrors(url, res, func) {
   try {
     return func();
   } catch (error) {
-    var errorJson;
-    if (error instanceof Meteor.Error) {
-      errorJson = {
-        error: error.error,
-        reason: error.reason,
-        details: error.details
-      };
-    } else if (error.sanitizedError instanceof Meteor.Error) {
-      errorJson = {
-        error: error.sanitizedError.error,
-        reason: error.sanitizedError.reason,
-        details: error.sanitizedError.details
-      };
-    } else {
-      console.log("Internal server error in " + url, error, error.stack);
-      errorJson = {
-        error: "internal-server-error",
-        reason: "Internal server error"
-      };
-    }
-
-    var code = 500;
-    if (_.isNumber(errorJson.error)) {
-      code = errorJson.error;
-    }
-
-    JsonRoutes.sendResult(res, code, errorJson);
+    JsonRoutes.sendResult(res, null, error);
   }
 }


### PR DESCRIPTION
Adds ability for `data` argument of `sendResult` to be an `Error`, and catches errors in json-routes and automatically responds.

End goal is to be able to do this:

```js
Meteor.methods({
  foo: function (obj) {
    check(obj, objSchema);
  }
});
```

And get full schema validation info in the response object. I think this will also automatically work for POST/PATCH on collections that have a schema attached via collection2 package.

Let me know your thoughts. Thanks!