### PR TITLE
Refactor bearer token auth to separate package

### DIFF
--- a/packages/rest-accounts-bearer-token/README.md
+++ b/packages/rest-accounts-bearer-token/README.md
@@ -1,0 +1,5 @@
+# simple:rest-accounts-bearer-token
+
+Authorize a `Meteor.user` using the standard bearer token `Authorization` 
+header. Sets the `request.userId` to the ID of the authorized user, so it can be 
+accessed in later middleware. 

--- a/packages/rest-accounts-bearer-token/accounts_bearer_token.js
+++ b/packages/rest-accounts-bearer-token/accounts_bearer_token.js
@@ -1,0 +1,60 @@
+var Fiber = Npm.require("fibers");
+
+// Add the authorized user ID, if any, to the request
+JsonRoutes.middleWare.use(function (req, res, next) {
+  Fiber(function () {
+    var userId = getUserIdFromRequest(req);
+    if (userId) {
+      req.userId = userId;
+    }
+    next();
+  }).run();
+});
+
+// Get the user ID from the standard bearer token authorization header
+function getUserIdFromRequest(req) {
+  if (! _.has(Package, "accounts-base")) {
+    return null;
+  }
+
+  // Looks like "Authorization: Bearer <token>"
+  var token = req.headers.authorization &&
+    req.headers.authorization.split(" ")[1];
+
+  if (! token) {
+    return null;
+  }
+
+  // Check token expiration
+  var tokenExpires = Package["accounts-base"].Accounts._tokenExpiration(token.when);
+  if (new Date() >= tokenExpires) {
+    throw new Meteor.Error("token-expired", "Your login token has expired. Please log in again.");
+  }
+
+  var user = Meteor.users.findOne({
+    "services.resume.loginTokens.hashedToken": hashToken(token)
+  });
+
+  if (user) {
+    return user._id;
+  } else {
+    return null;
+  }
+}
+
+function hashToken(unhashedToken) {
+  check(unhashedToken, String);
+
+  // The Accounts._hashStampedToken function has a questionable API where
+  // it actually takes an object of which it only uses one property, so don't
+  // give it any more properties than it needs.
+  var hashStampedTokenArg = { token: unhashedToken };
+  var hashStampedTokenReturn = Package["accounts-base"].Accounts._hashStampedToken(hashStampedTokenArg);
+  check(hashStampedTokenReturn, {
+    hashedToken: String
+  });
+
+  // Accounts._hashStampedToken also returns an object, get rid of it and just
+  // get the one property we want.
+  return hashStampedTokenReturn.hashedToken;
+}

--- a/packages/rest-accounts-bearer-token/accounts_bearer_token_tests.js
+++ b/packages/rest-accounts-bearer-token/accounts_bearer_token_tests.js
@@ -1,0 +1,40 @@
+if (Meteor.isServer) {
+  JsonRoutes.add("get", "accounts-bearer-token", function (req, res) {
+    JsonRoutes.sendResult(res, 200, req.userId);
+  });
+}
+else { // Meteor.isClient
+  var token;
+  var userId;
+  testAsyncMulti("Bearer Token Middleware - should set req.userId using standard bearer token", [
+    function (test, expect) {
+      Meteor.call("clearUsers", expect(function () {}));
+    },
+    function (test, expect) {
+      HTTP.post("/users/register", { data: {
+        username: "test",
+        email: "test@test.com",
+        password: "test"
+      }}, expect(function (err, res) {
+        test.equal(err, null);
+        test.isTrue(Match.test(res.data, {
+          id: String,
+          token: String,
+          tokenExpires: String
+        }));
+
+        token = res.data.token;
+        userId = res.data.id;
+      }));
+    },
+    function (test, expect) {
+      // Test custom endpoint
+      HTTP.get("/accounts-bearer-token", {
+        headers: { Authorization: "Bearer " + token }
+      }, expect(function (err, res) {
+        test.equal(err, null);
+        test.equal(res.data, userId);
+      }));
+    }
+  ]);
+}

--- a/packages/rest-accounts-bearer-token/package.js
+++ b/packages/rest-accounts-bearer-token/package.js
@@ -1,0 +1,31 @@
+Package.describe({
+  name: 'simple:rest-accounts-bearer-token',
+  version: '0.0.1',
+  // Brief, one-line summary of the package.
+  summary: 'Authorize user via standard bearer token',
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/stubailo/meteor-rest',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.0');
+  api.use('simple:json-routes');
+
+  api.use([
+    'accounts-base'
+  ], 'server', {weak: true});
+
+  api.addFiles('accounts_bearer_token.js', 'server');
+});
+
+Package.onTest(function(api) {
+  api.use('simple:rest-accounts-bearer-token');
+  api.use('tinytest');
+  api.use("test-helpers");
+  api.use('http');
+  api.use('simple:json-routes');
+  api.addFiles('accounts_bearer_token_tests.js');
+});

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,4 +3,5 @@
 meteor test-packages \
   "$(pwd)/packages/rest" \
   "$(pwd)/packages/json-routes" \
+  "$(pwd)/packages/rest-accounts-bearer-token" \
   "$(pwd)/packages/rest-accounts-password"


### PR DESCRIPTION
- Resolve #23
- Create a new middleware package for handling bearer token auth for a
  Meteor.user (simple:rest-accounts-bearer-token)
  - Move any bearer token auth logic from simple:rest to the new package
  - Add a test for auth in custom endpoint
  - Add a super simple README

simple-rest:
  - In methods and publications, check for the authorized user at
    request.userId instead of checking for the bearer token. This way,
    any auth can be plugged into simple:rest in place of the bearer
    token auth.