### PR TITLE
Make 'method' param in JsonRoutes.add() case-insensitive

### DIFF
--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -3,7 +3,7 @@
 <https://atmospherejs.com/simple/json-routes>
 
 The simplest bare-bones way to define server-side JSON API endpoints, without
-any extra functionality. Based on [connect-route](https://github.com/baryshev/connect-route).
+any extra functionality. Based on [connect-route].
 
 ## Example
 
@@ -22,23 +22,24 @@ JsonRoutes.add("get", "/posts/:id", function (req, res, next) {
 Add a server-side route that returns JSON.
 
 - `method` - The HTTP method that this route should accept: `"get"`, `"post"`,
-etc. See the full list [here](https://github.com/baryshev/connect-route/blob/06f92e07dc8e4690f7f788df39b37b5db4b06f90/lib/connect-route.js#L4).
+  etc. See the full list [here][connect-route L4]. The method name is 
+  case-insensitive, so `'get'` and `'GET'` are both acceptable.
 - `path` - The path, possibly with parameters prefixed with a `:`. See the
-example.
+  example.
 - `handler(request, response, next)` - A handler function for this route.
-`request` is a Node request object, `response` is a Node response object, `next`
-is a callback to call to let the next middleware handle this route. You don't
-need to use this normally.
+  `request` is a Node request object, `response` is a Node response object, 
+  `next` is a callback to call to let the next middleware handle this route. You 
+  don't need to use this normally.
 
 ### JsonRoutes.sendResult(response, code, data)
 
 Return data fom a route.
 
 - `response` - the Node response object you got as an argument to your handler
-function.
+  function.
 - `code` - the status code to send. `200` for OK, `500` for internal error, etc.
 - `data` - the data you want to send back, will be sent as serialized JSON with
-content type `application/json`.
+  content type `application/json`.
 
 ### JsonRoutes.setResponseHeaders(headerObj)
 
@@ -53,7 +54,8 @@ Set the headers returned by `JsonRoutes.sendResult`. Default value is:
 
 ## Adding middlewares
 
-If you want to insert connect middleware and ensure that it runs before your REST route is hit, use `JsonRoutes.middleWare`.
+If you want to insert connect middleware and ensure that it runs before your 
+REST route is hit, use `JsonRoutes.middleWare`.
 
 ```js
 JsonRoutes.middleWare.use(function (req, res, next) {
@@ -64,6 +66,15 @@ JsonRoutes.middleWare.use(function (req, res, next) {
 
 ## Change log
 
+#### Unreleased
+
+Allow case-insensitive method names to be passed as the first param to 
+`JsonRoutes.add()` (e.g., `JsonRoutes.add('get',...)` and 
+`JsonRoutes.add('GET',...)` are both acceptable)
+
 #### 1.0.3
 
 Add `JsonRoutes.middleWare`
+
+[connect-route]: https://github.com/baryshev/connect-route
+[connect-route L4]: https://github.com/baryshev/connect-route/blob/06f92e07dc8e4690f7f788df39b37b5db4b06f90/lib/connect-route.js#L4

--- a/packages/json-routes/json-routes-tests.js
+++ b/packages/json-routes/json-routes-tests.js
@@ -1,1 +1,34 @@
-// This package is tested in the `simple:rest` package.
+// This package is also tested in the `simple:rest` package.
+if (Meteor.isServer) {
+  JsonRoutes.add("GET", "case-insensitive-method-1", function (req, res) {
+    JsonRoutes.sendResult(res, 200, true);
+  });
+  JsonRoutes.add("Get", "case-insensitive-method-2", function (req, res) {
+    JsonRoutes.sendResult(res, 200, true);
+  });
+  JsonRoutes.add("get", "case-insensitive-method-3", function (req, res) {
+    JsonRoutes.sendResult(res, 200, true);
+  });
+}
+else { // Meteor.isClient
+  testAsyncMulti("JSON Routes - should support case-insensitive HTTP method types", [
+    function (test, expect) {
+      HTTP.get("/case-insensitive-method-1", expect(function (err, res) {
+        test.equal(err, null);
+        test.equal(res.data, true);
+      }));
+    },
+    function (test, expect) {
+      HTTP.get("/case-insensitive-method-2", expect(function (err, res) {
+        test.equal(err, null);
+        test.equal(res.data, true);
+      }));
+    },
+    function (test, expect) {
+      HTTP.get("/case-insensitive-method-3", expect(function (err, res) {
+        test.equal(err, null);
+        test.equal(res.data, true);
+      }));
+    }
+  ]);
+}

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -33,7 +33,7 @@ JsonRoutes.add = function (method, path, handler) {
     path: path
   });
 
-  connectRouter[method](path, function (req, res, next) {
+  connectRouter[method.toLowerCase()](path, function (req, res, next) {
     Fiber(function () {
       handler(req, res, next);
     }).run();


### PR DESCRIPTION
json-routes:
- Resolve Issue #31
- Update README
  - Add info on param being case-insensitive
  - Enforce 80 character line limit
  - Create a table of links for long URLs
  - Fix indentation in bullet-lists to improve readability of raw README
- Update change log