### PR TITLE
Better error handling

### DIFF
--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -35,10 +35,17 @@ Add a server-side route that returns JSON.
 
 Return data fom a route.
 
-- `response` - the Node response object you got as an argument to your handler function.
-- `code` - the status code to send. `200` for OK, `500` for internal error, etc. If the `data` argument is an `Error` type, this is overwritten based on the error.
-- `data` - the data you want to send back. This is serialized to JSON with
-content type `application/json`. If `undefined`, there will be no response body. If an `Error` type, a JSON representation of the error details will be sent.
+- `response` - Required. The Node response object you got as an argument to your handler function.
+- `code` - Optional. The status code to send. `200` for OK, `500` for internal error, etc. Default is 200.
+- `data` - Optional. The data you want to send back. This is serialized to JSON with content type `application/json`. If `undefined`, there will be no response body.
+
+### JsonRoutes.sendError(response, code, error)
+
+Return error response fom a route.
+
+- `response` - Required. The Node response object you got as an argument to your handler function.
+- `code` - Optional. The status code to send. Default is taken from `error.statusCode` if present. Otherwise 400.
+- `error` - Optional. An `Error` or `Meteor.Error` object. A JSON representation of the error details will be sent. You can set `error.data` or `error.sanitizedError.data` to some extra data to be serialized and sent with the response.
 
 ### JsonRoutes.setResponseHeaders(headerObj)
 
@@ -68,8 +75,8 @@ JsonRoutes.middleWare.use(function (req, res, next) {
 #### Unreleased
 
 - Allow case-insensitive method names to be passed as the first param to `JsonRoutes.add()` (e.g., `JsonRoutes.add('get',...)` and `JsonRoutes.add('GET',...)` are both acceptable)
-- Add ability for `data` argument of `sendResult` to be an `Error`
-- Catch handler errors and automatically send a response. Look for `statusCode` and `jsonResponse` properties on thrown errors.
+- Add `JsonRoutes.sendError` with automatic parsing of error objects.
+- Catch handler errors and automatically send a response. Look for `statusCode` and `data` properties on thrown errors.
 
 #### 1.0.3
 

--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -41,10 +41,10 @@ Return data fom a route.
 
 ### JsonRoutes.sendError(response, code, error)
 
-Return error response fom a route.
+Return an error response from a route.
 
 - `response` - Required. The Node response object you got as an argument to your handler function.
-- `code` - Optional. The status code to send. Default is taken from `error.statusCode` if present. Otherwise 400.
+- `code` - Optional. The status code to send. Default is 500.
 - `error` - Optional. An `Error` or `Meteor.Error` object. A JSON representation of the error details will be sent. You can set `error.data` or `error.sanitizedError.data` to some extra data to be serialized and sent with the response.
 
 ### JsonRoutes.setResponseHeaders(headerObj)

--- a/packages/json-routes/README.md
+++ b/packages/json-routes/README.md
@@ -35,15 +35,14 @@ Add a server-side route that returns JSON.
 
 Return data fom a route.
 
-- `response` - the Node response object you got as an argument to your handler
-  function.
-- `code` - the status code to send. `200` for OK, `500` for internal error, etc.
-- `data` - the data you want to send back, will be sent as serialized JSON with
-  content type `application/json`.
+- `response` - the Node response object you got as an argument to your handler function.
+- `code` - the status code to send. `200` for OK, `500` for internal error, etc. If the `data` argument is an `Error` type, this is overwritten based on the error.
+- `data` - the data you want to send back. This is serialized to JSON with
+content type `application/json`. If `undefined`, there will be no response body. If an `Error` type, a JSON representation of the error details will be sent.
 
 ### JsonRoutes.setResponseHeaders(headerObj)
 
-Set the headers returned by `JsonRoutes.sendResult`. Default value is:
+Set the headers used by `JsonRoutes.sendResult` for the response. Default value is:
 
 ```js
 {
@@ -68,9 +67,9 @@ JsonRoutes.middleWare.use(function (req, res, next) {
 
 #### Unreleased
 
-Allow case-insensitive method names to be passed as the first param to 
-`JsonRoutes.add()` (e.g., `JsonRoutes.add('get',...)` and 
-`JsonRoutes.add('GET',...)` are both acceptable)
+- Allow case-insensitive method names to be passed as the first param to `JsonRoutes.add()` (e.g., `JsonRoutes.add('get',...)` and `JsonRoutes.add('GET',...)` are both acceptable)
+- Add ability for `data` argument of `sendResult` to be an `Error`
+- Catch handler errors and automatically send a response. Look for `statusCode` and `jsonResponse` properties on thrown errors.
 
 #### 1.0.3
 

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -37,7 +37,11 @@ JsonRoutes.add = function (method, path, handler) {
 
   connectRouter[method.toLowerCase()](path, function (req, res, next) {
     Fiber(function () {
-      handler(req, res, next);
+      try {
+        handler(req, res, next);
+      } catch (err) {
+        JsonRoutes.sendResult(res, null, err);
+      }
     }).run();
   });
 };
@@ -57,15 +61,96 @@ var setHeaders = function (res) {
   });
 };
 
-JsonRoutes.sendResult = function (res, code, json) {
-  setHeaders(res);
-  res.statusCode = code;
+// Convert `Error` objects to JSON representations
+JsonRoutes._errorToJson = function (data) {
+  if (!data) {
+    return data;
+  }
 
+  // If an error has a `jsonResponse` property, we
+  // send that. This allows packages to check whether
+  // JsonRoutes package is used and if so, to include
+  // a specific error response body with the errors they throw.
+  if (data instanceof Meteor.Error) {
+    return data.jsonResponse || {
+      error: data.error,
+      reason: data.reason,
+      details: data.details
+    };
+  } else if (data.sanitizedError instanceof Meteor.Error) {
+    return data.sanitizedError.jsonResponse || {
+      error: data.sanitizedError.error,
+      reason: data.sanitizedError.reason,
+      details: data.sanitizedError.details
+    };
+  } else if (data instanceof Error) {
+    return data.jsonResponse || {
+      error: "internal-server-error",
+      reason: "Internal server error"
+    };
+  }
+
+  // Data was not an error
+  return data;
+};
+
+var setStatusCode = function (res, code, data) {
+  if (!data) {
+    res.statusCode = code || 200;
+    return;
+  }
+
+  // If an error has a `statusCode` property, we
+  // use that. This allows packages to check whether
+  // JsonRoutes package is used and if so, to include
+  // a specific error status code with the errors they throw.
+  if (data instanceof Meteor.Error) {
+    res.statusCode = data.statusCode || 400;
+  } else if (data.sanitizedError instanceof Meteor.Error) {
+    res.statusCode = data.sanitizedError.statusCode || data.statusCode || 400;
+  } else if (data instanceof Error) {
+    res.statusCode = data.statusCode || 500;
+  } else {
+    res.statusCode = code || 200;
+  }
+};
+
+/**
+ * Sets the response headers, status code, and body, and ends it.
+ * The JSON response will be pretty printed if NODE_ENV is `development`.
+ *
+ * @param {Object}                            res  Response object
+ * @param {Number}                            code HTTP status code. If `json`
+ *                                                 argument is an `Error`
+ *                                                 object, this will be
+ *                                                 overwritten based on the
+ *                                                 error.
+ * @param {Object|Array|null|undefined|Error} data The object to stringify as
+ *                                                 the response. If `null`, the
+ *                                                 response will be "null". If
+ *                                                 `undefined`, there will be
+ *                                                 no response body. If an
+ *                                                 `Error` type, a JSON
+ *                                                 representation of the
+ *                                                 error details will be sent.
+ */
+JsonRoutes.sendResult = function (res, code, data) {
+  // Set headers on response
+  setHeaders(res);
+  // Set status code on response
+  setStatusCode(res, code, data);
+
+  // Convert `Error` objects to JSON representations
+  var json = JsonRoutes._errorToJson(data);
+
+  // Set response body
   if (json !== undefined) {
-    var spacer = process.env.NODE_ENV === 'development' ? 2 : null;
+    var shouldPrettyPrint = (process.env.NODE_ENV === 'development');
+    var spacer = shouldPrettyPrint ? 2 : null;
     res.setHeader("Content-type", "application/json");
     res.write(JSON.stringify(json, null, spacer));
   }
 
+  // Send the response
   res.end();
 };

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -40,7 +40,7 @@ JsonRoutes.add = function (method, path, handler) {
       try {
         handler(req, res, next);
       } catch (err) {
-        JsonRoutes.sendError(res, null, err);
+        JsonRoutes.sendError(res, getStatusCodeFromError(err), err);
       }
     }).run();
   });
@@ -105,8 +105,7 @@ JsonRoutes.sendResult = function (res, code, data) {
  * The JSON response will be pretty printed if NODE_ENV is `development`.
  *
  * @param {Object} res Response object
- * @param {Number} code The status code to send. Default is taken from
- *   `error.statusCode` if present. Otherwise 400.
+ * @param {Number} code The status code to send. Default is 500.
  * @param {Error|Meteor.Error} error The error object to stringify as
  *   the response. A JSON representation of the error details will be
  *   sent. You can set `error.data` or `error.sanitizedError.data` to
@@ -120,7 +119,7 @@ JsonRoutes.sendError = function (res, code, error) {
   error = error || new Error();
 
   // Set status code on response
-  res.statusCode = code || getStatusCodeFromError(error);
+  res.statusCode = code || 500;
 
   // Convert `Error` objects to JSON representations
   var json = JsonRoutes._errorToJson(error);

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -59,15 +59,15 @@ JsonRoutes.setResponseHeaders = function (headers) {
  * Convert `Error` objects to plain response objects suitable
  * for serialization.
  *
- * @param {Any} [data] Should be a Meteor.Error or Error object. If anything
+ * @param {Any} [error] Should be a Meteor.Error or Error object. If anything
  *   else is passed or this argument isn't provided, a generic
  *   "internal-server-error" object is returned
  */
-JsonRoutes._errorToJson = function (data) {
-  if (data instanceof Meteor.Error) {
-    return buildErrorResponse(data);
-  } else if (data && data.sanitizedError instanceof Meteor.Error) {
-    return buildErrorResponse(data.sanitizedError);
+JsonRoutes._errorToJson = function (error) {
+  if (error instanceof Meteor.Error) {
+    return buildErrorResponse(error);
+  } else if (error && error.sanitizedError instanceof Meteor.Error) {
+    return buildErrorResponse(error.sanitizedError);
   } else {
     return {
       error: 'internal-server-error',
@@ -138,7 +138,7 @@ function setHeaders(res) {
 }
 
 function getStatusCodeFromError(error) {
-  // So that we don't have to keep checking if error exists
+  // Bail out if no error passed in
   if (! error) {
     return 500;
   }
@@ -166,17 +166,12 @@ function getStatusCodeFromError(error) {
   return 500;
 }
 
-function buildErrorResponse(obj) {
+function buildErrorResponse(errObj) {
   // If an error has a `data` property, we
   // send that. This allows packages to include
   // extra client-safe data with the errors they throw.
-  var response = {};
-  _.each(['error', 'reason', 'details', 'data'], function (prop) {
-    if (obj[prop] !== undefined) {
-      response[prop] = obj[prop];
-    }
-  });
-  return response;
+  var fields = ['error', 'reason', 'details', 'data'];
+  return _.pick(errObj, fields);
 }
 
 function writeJsonToBody(res, json) {

--- a/packages/json-routes/json-routes.js
+++ b/packages/json-routes/json-routes.js
@@ -119,20 +119,13 @@ var setStatusCode = function (res, code, data) {
  * Sets the response headers, status code, and body, and ends it.
  * The JSON response will be pretty printed if NODE_ENV is `development`.
  *
- * @param {Object}                            res  Response object
- * @param {Number}                            code HTTP status code. If `json`
- *                                                 argument is an `Error`
- *                                                 object, this will be
- *                                                 overwritten based on the
- *                                                 error.
+ * @param {Object} res Response object
+ * @param {Number} code HTTP status code. If `json` argument is an `Error`
+ *   object, this will be overwritten based on the error.
  * @param {Object|Array|null|undefined|Error} data The object to stringify as
- *                                                 the response. If `null`, the
- *                                                 response will be "null". If
- *                                                 `undefined`, there will be
- *                                                 no response body. If an
- *                                                 `Error` type, a JSON
- *                                                 representation of the
- *                                                 error details will be sent.
+ *   the response. If `null`, the response will be "null". If
+ *   `undefined`, there will be no response body. If an
+ *   `Error` type, a JSON representation of the error details will be sent.
  */
 JsonRoutes.sendResult = function (res, code, data) {
   // Set headers on response

--- a/packages/rest-accounts-password/rest-login.js
+++ b/packages/rest-accounts-password/rest-login.js
@@ -7,60 +7,53 @@ JsonRoutes.add("options", "/users/login", function (req, res) {
 JsonRoutes.add("post", "/users/login", function (req, res) {
   var options = req.body;
 
-  try {
-
-    var user;
-    if( options.hasOwnProperty("email") ) {
-      check(options, {
-        email: String,
-        password: String
-      });
-      user = Meteor.users.findOne({ "emails.address": options.email });
-    } else {
-      check(options, {
-        username: String,
-        password: String
-      });
-      user = Meteor.users.findOne({ username: options.username });
-    }
-
-    if (! user) {
-      throw new Meteor.Error("not-found",
-        "User with that username or email address not found.");
-    }
-
-    var result = Accounts._checkPassword(user, options.password);
-    check(result, {
-      userId: String,
-      error: Match.Optional(Meteor.Error)
+  var user;
+  if( options.hasOwnProperty("email") ) {
+    check(options, {
+      email: String,
+      password: String
     });
-
-    if (result.error) {
-      throw result.error;
-    }
-
-    var stampedLoginToken = Accounts._generateStampedLoginToken();
-    check(stampedLoginToken, {
-      token: String,
-      when: Date
+    user = Meteor.users.findOne({ "emails.address": options.email });
+  } else {
+    check(options, {
+      username: String,
+      password: String
     });
-
-    Accounts._insertLoginToken(result.userId, stampedLoginToken);
-
-    var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
-    check(tokenExpiration, Date);
-
-    JsonRoutes.sendResult(res, 200, {
-      id: result.userId,
-      token: stampedLoginToken.token,
-      tokenExpires: tokenExpiration
-    });
-  } catch (err) {
-    var errJson = convertErrorToJson(err);
-    console.log("Error in login: ", err);
-
-    JsonRoutes.sendResult(res, 500, errJson);
+    user = Meteor.users.findOne({ username: options.username });
   }
+
+  if (! user) {
+    throw new Meteor.Error("not-found",
+      "User with that username or email address not found.");
+  }
+
+  var result = Accounts._checkPassword(user, options.password);
+  check(result, {
+    userId: String,
+    error: Match.Optional(Meteor.Error)
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  var stampedLoginToken = Accounts._generateStampedLoginToken();
+  check(stampedLoginToken, {
+    token: String,
+    when: Date
+  });
+
+  Accounts._insertLoginToken(result.userId, stampedLoginToken);
+
+  var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
+  check(tokenExpiration, Date);
+
+  JsonRoutes.sendResult(res, 200, {
+    id: result.userId,
+    token: stampedLoginToken.token,
+    tokenExpires: tokenExpiration
+  });
+
 });
 
 JsonRoutes.add("options", "/users/register", function (req, res) {
@@ -70,60 +63,32 @@ JsonRoutes.add("options", "/users/register", function (req, res) {
 JsonRoutes.add("post", "/users/register", function (req, res) {
   var options = req.body;
 
-  try {
-    check(options, {
-      username: Match.Optional(String),
-      email: Match.Optional(String),
-      password: String
-    });
+  check(options, {
+    username: Match.Optional(String),
+    email: Match.Optional(String),
+    password: String
+  });
 
-    var userId = Accounts.createUser(
-      _.pick(options, "username", "email", "password"));
+  var userId = Accounts.createUser(
+    _.pick(options, "username", "email", "password"));
 
-    // Log in the new user and send back a token
-    var stampedLoginToken = Accounts._generateStampedLoginToken();
-    check(stampedLoginToken, {
-      token: String,
-      when: Date
-    });
+  // Log in the new user and send back a token
+  var stampedLoginToken = Accounts._generateStampedLoginToken();
+  check(stampedLoginToken, {
+    token: String,
+    when: Date
+  });
 
-    // This adds the token to the user
-    Accounts._insertLoginToken(userId, stampedLoginToken);
+  // This adds the token to the user
+  Accounts._insertLoginToken(userId, stampedLoginToken);
 
-    var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
-    check(tokenExpiration, Date);
+  var tokenExpiration = Accounts._tokenExpiration(stampedLoginToken.when);
+  check(tokenExpiration, Date);
 
-    // Return the same things the login method returns
-    JsonRoutes.sendResult(res, 200, {
-      token: stampedLoginToken.token,
-      tokenExpires: tokenExpiration,
-      id: userId
-    });
-  } catch (err) {
-    var errJson = convertErrorToJson(err);
-    console.log("Error in registration: ", err);
-
-    JsonRoutes.sendResult(res, 500, errJson);
-  }
+  // Return the same things the login method returns
+  JsonRoutes.sendResult(res, 200, {
+    token: stampedLoginToken.token,
+    tokenExpires: tokenExpiration,
+    id: userId
+  });
 });
-
-// Just like in DDP, send a sanitized error over HTTP
-function convertErrorToJson(err) {
-  if (err.sanitizedError) {
-    var sE = err.sanitizedError;
-    return {
-      error: sE.error,
-      reason: sE.reason
-    };
-  } else if (err.errorType === "Meteor.Error") {
-    return {
-      error: err.error,
-      reason: err.reason
-    };
-  } else {
-    return {
-      error: "internal-server-error",
-      reason: "Internal server error."
-    };
-  }
-}

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -121,6 +121,14 @@ Meteor.method("add-numbers", function (a, b) {
 })
 ```
 
+#### Setting HTTP status code
+
+By default, successful method requests will respond with status code 200 and errors will respond with status code 400. To override this in your method:
+
+```js
+this.setHttpStatusCode(201);
+```
+
 ### Collection methods
 
 The default Meteor collection methods (insert, update, and remove) are also automatically exposed when this package is added. 

--- a/packages/rest/rest-tests.js
+++ b/packages/rest/rest-tests.js
@@ -92,7 +92,7 @@ if (Meteor.isServer) {
   });
 
   Meteor.method("status-code", function () {
-    this.setStatusCode(222);
+    this.setHttpStatusCode(222);
   });
 
   Meteor.method("throws-error", function () {
@@ -111,24 +111,24 @@ if (Meteor.isServer) {
 
   Meteor.method("throws-error-custom", function () {
     var error = new Error('Bad');
-    error.jsonResponse = {ding: 'dong'};
+    error.data = {ding: 'dong'};
     error.statusCode = 499;
     throw error;
   });
 
   Meteor.method("throws-meteor-error-custom", function () {
     var error = new Meteor.Error('foo-bar', 'Foo');
-    error.jsonResponse = {ding: 'dong'};
+    error.data = {ding: 'dong'};
     error.statusCode = 499;
     throw error;
   });
 
   Meteor.method("throws-sanitized-error-custom", function () {
     var error = new Error('Bad');
-    error.jsonResponse = {ding: 'ding'};
+    error.data = {ding: 'ding'};
     error.statusCode = 999;
     error.sanitizedError = new Meteor.Error('foo-bar', 'Foo');
-    error.sanitizedError.jsonResponse = {ding: 'dong'};
+    error.sanitizedError.data = {ding: 'dong'};
     error.sanitizedError.statusCode = 499;
     throw error;
   });
@@ -328,7 +328,7 @@ if (Meteor.isServer) {
     function (test, expect) {
       HTTP.post("/methods/throws-error-custom", expect(function (err, res) {
         test.isTrue(!!err);
-        test.equal(res.data.ding, "dong");
+        test.equal(res.data.error, "internal-server-error");
         test.equal(res.statusCode, 499);
       }));
     }
@@ -339,7 +339,7 @@ if (Meteor.isServer) {
       HTTP.post("/methods/throws-meteor-error-custom",
                 expect(function (err, res) {
                   test.isTrue(!!err);
-                  test.equal(res.data.ding, "dong");
+                  test.equal(res.data.data.ding, "dong");
                   test.equal(res.statusCode, 499);
                 })
                );
@@ -351,7 +351,7 @@ if (Meteor.isServer) {
       HTTP.post("/methods/throws-sanitized-error-custom",
                 expect(function (err, res) {
                   test.isTrue(!!err);
-                  test.equal(res.data.ding, "dong");
+                  test.equal(res.data.data.ding, "dong");
                   test.equal(res.statusCode, 499);
                 })
                );

--- a/packages/rest/rest-tests.js
+++ b/packages/rest/rest-tests.js
@@ -91,6 +91,48 @@ if (Meteor.isServer) {
     }
   });
 
+  Meteor.method("status-code", function () {
+    this.setStatusCode(222);
+  });
+
+  Meteor.method("throws-error", function () {
+    throw new Error('Bad');
+  });
+
+  Meteor.method("throws-meteor-error", function () {
+    throw new Meteor.Error('foo-bar', 'Foo');
+  });
+
+  Meteor.method("throws-sanitized-error", function () {
+    var error = new Error('Bad');
+    error.sanitizedError = new Meteor.Error('foo-bar', 'Foo');
+    throw error;
+  });
+
+  Meteor.method("throws-error-custom", function () {
+    var error = new Error('Bad');
+    error.jsonResponse = {ding: 'dong'};
+    error.statusCode = 499;
+    throw error;
+  });
+
+  Meteor.method("throws-meteor-error-custom", function () {
+    var error = new Meteor.Error('foo-bar', 'Foo');
+    error.jsonResponse = {ding: 'dong'};
+    error.statusCode = 499;
+    throw error;
+  });
+
+  Meteor.method("throws-sanitized-error-custom", function () {
+    var error = new Error('Bad');
+    error.jsonResponse = {ding: 'ding'};
+    error.statusCode = 999;
+    error.sanitizedError = new Meteor.Error('foo-bar', 'Foo');
+    error.sanitizedError.jsonResponse = {ding: 'dong'};
+    error.sanitizedError.statusCode = 499;
+    throw error;
+  });
+
   Meteor.method("add-all-arguments", function (a, b, c) {
     return a + b + c;
   });
@@ -237,6 +279,90 @@ if (Meteor.isServer) {
       }, expect(function (err, res) {
         test.equal(err, null);
         test.equal(res.data, 5);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("calling method with wrong auth", [
+    function (test, expect) {
+      HTTP.post("/methods/return-five-auth", {
+        headers: { Authorization: "Bearer foo" }
+      }, expect(function (err, res) {
+        test.equal(err, null);
+        test.equal(res.data, 0);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-error", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.error, "internal-server-error");
+        test.equal(res.statusCode, 500);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method meteor error", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-meteor-error", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.reason, "Foo");
+        test.equal(res.statusCode, 400);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error with meteor error", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-sanitized-error", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.reason, "Foo");
+        test.equal(res.statusCode, 400);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method error custom", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-error-custom", expect(function (err, res) {
+        test.isTrue(!!err);
+        test.equal(res.data.ding, "dong");
+        test.equal(res.statusCode, 499);
+      }));
+    }
+  ]);
+
+  testAsyncMulti("method meteor error custom", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-meteor-error-custom",
+                expect(function (err, res) {
+                  test.isTrue(!!err);
+                  test.equal(res.data.ding, "dong");
+                  test.equal(res.statusCode, 499);
+                })
+               );
+    }
+  ]);
+
+  testAsyncMulti("method error with meteor error custom", [
+    function (test, expect) {
+      HTTP.post("/methods/throws-sanitized-error-custom",
+                expect(function (err, res) {
+                  test.isTrue(!!err);
+                  test.equal(res.data.ding, "dong");
+                  test.equal(res.statusCode, 499);
+                })
+               );
+    }
+  ]);
+
+  testAsyncMulti("method status code", [
+    function (test, expect) {
+      HTTP.post("/methods/status-code", expect(function (err, res) {
+        test.isFalse(!!err);
+        test.equal(res.statusCode, 222);
       }));
     }
   ]);

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -151,7 +151,7 @@ function addHTTPMethod(httpMethod, url, handler, options) {
       unblock: function () {
         // no-op
       },
-      setStatusCode: function (code) {
+      setHttpStatusCode: function (code) {
         statusCode = code;
       }
     };

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -25,38 +25,36 @@ Meteor.publish = function (name, handler, options) {
   });
 
   JsonRoutes.add(httpOptions.httpMethod, httpOptions.url, function (req, res) {
-    catchAndReportErrors(httpOptions.url, res, function () {
-      var userId = req.userId || null;
+    var userId = req.userId || null;
 
-      var httpSubscription = new HttpSubscription({
-        request: req,
-        userId: userId
-      });
-
-      httpSubscription.on("ready", function (response) {
-        JsonRoutes.sendResult(res, 200, response);
-      });
-
-      var handlerArgs = httpOptions.getArgsFromRequest(req);
-
-      var handlerReturn = handler.apply(httpSubscription, handlerArgs);
-
-      // Fast track for publishing cursors - we don't even need livequery here,
-      // just making a normal DB query
-      if (handlerReturn && handlerReturn._publishCursor) {
-        httpPublishCursor(handlerReturn, httpSubscription);
-        httpSubscription.ready();
-      } else if (handlerReturn && _.isArray(handlerReturn)) {
-        // We don't need to run the checks to see if
-        // the cursors overlap and stuff
-        // because calling Meteor.publish will do that for us :]
-        _.each(handlerReturn, function (cursor) {
-          httpPublishCursor(cursor, httpSubscription);
-        });
-
-        httpSubscription.ready();
-      }
+    var httpSubscription = new HttpSubscription({
+      request: req,
+      userId: userId
     });
+
+    httpSubscription.on("ready", function (response) {
+      JsonRoutes.sendResult(res, 200, response);
+    });
+
+    var handlerArgs = httpOptions.getArgsFromRequest(req);
+
+    var handlerReturn = handler.apply(httpSubscription, handlerArgs);
+
+    // Fast track for publishing cursors - we don't even need livequery here,
+    // just making a normal DB query
+    if (handlerReturn && handlerReturn._publishCursor) {
+      httpPublishCursor(handlerReturn, httpSubscription);
+      httpSubscription.ready();
+    } else if (handlerReturn && _.isArray(handlerReturn)) {
+      // We don't need to run the checks to see if
+      // the cursors overlap and stuff
+      // because calling Meteor.publish will do that for us :]
+      _.each(handlerReturn, function (cursor) {
+        httpPublishCursor(cursor, httpSubscription);
+      });
+
+      httpSubscription.ready();
+    }
   });
 };
 
@@ -139,26 +137,28 @@ function addHTTPMethod(httpMethod, url, handler, options) {
   });
 
   JsonRoutes.add(httpMethod, url, function (req, res) {
-    catchAndReportErrors(url, res, function () {
-      var userId = req.userId || null;
+    var userId = req.userId || null;
+    var statusCode = 200;
 
-      // XXX replace with a real one?
-      var methodInvocation = {
-        userId: userId,
-        setUserId: function () {
-          throw Error("setUserId not implemented in this " +
+    // XXX replace with a real one?
+    var methodInvocation = {
+      userId: userId,
+      setUserId: function () {
+        throw Error("setUserId not implemented in this " +
                       "version of simple:rest");
-        },
-        isSimulation: false,
-        unblock: function () {
-          // no-op
-        }
-      };
+      },
+      isSimulation: false,
+      unblock: function () {
+        // no-op
+      },
+      setStatusCode: function (code) {
+        statusCode = code;
+      }
+    };
 
-      var handlerArgs = options.getArgsFromRequest(req);
-      var handlerReturn = handler.apply(methodInvocation, handlerArgs);
-      JsonRoutes.sendResult(res, 200, handlerReturn);
-    });
+    var handlerArgs = options.getArgsFromRequest(req);
+    var handlerReturn = handler.apply(methodInvocation, handlerArgs);
+    JsonRoutes.sendResult(res, statusCode, handlerReturn);
   });
 }
 
@@ -193,38 +193,4 @@ function defaultGetArgsFromRequest(req) {
   });
 
   return args;
-}
-
-function catchAndReportErrors(url, res, func) {
-  try {
-    return func();
-  } catch (error) {
-    var errorJson;
-    if (error instanceof Meteor.Error) {
-      errorJson = {
-        error: error.error,
-        reason: error.reason,
-        details: error.details
-      };
-    } else if (error.sanitizedError instanceof Meteor.Error) {
-      errorJson = {
-        error: error.sanitizedError.error,
-        reason: error.sanitizedError.reason,
-        details: error.sanitizedError.details
-      };
-    } else {
-      console.log("Internal server error in " + url, error, error.stack);
-      errorJson = {
-        error: "internal-server-error",
-        reason: "Internal server error"
-      };
-    }
-
-    var code = 500;
-    if (_.isNumber(errorJson.error)) {
-      code = errorJson.error;
-    }
-
-    JsonRoutes.sendResult(res, code, errorJson);
-  }
 }


### PR DESCRIPTION
- Add ability for `data` argument of `sendResult` to be an `Error`
- Catch handler errors and automatically send a response. Look for `statusCode` and `jsonResponse` properties on thrown errors.
- Add `this.setStatusCode` in methods

Fixes https://github.com/stubailo/meteor-rest/issues/17