### PR TITLE
re #106 - config for customizing paths

### DIFF
--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -9,8 +9,13 @@ SimpleRest = {};
 // Also:
 //    objectIdCollections: ['widgets', 'doodles']
 SimpleRest._config = {
-	methodUrlPrefix: 'methods/',
-	publicationUrlPrefix: 'publications/'
+  urlTransform: (type, name) => {
+    if (type === 'method') return `${SimpleRest._config.methodUrlPrefix}${name}`,
+    if (type === 'publications') return `${SimpleRest._config.publicationUrlPrefix}${name}`,
+    throw new Meteor.Error(404, `Unkown REST type: ${type} name: ${name}`);
+  },
+  methodUrlPrefix: 'methods/',
+  publicationUrlPrefix: 'publications/',
 };
 SimpleRest.configure = function (config) {
   return _.extend(SimpleRest._config, config);
@@ -32,7 +37,7 @@ SimpleRest.setMethodOptions = function (name, options) {
   options = options || {};
 
   _.defaults(options, {
-    url: SimpleRest._config.methodUrlPrefix + name,
+    url: SimpleRest._config.urlTransform('method', name),
     getArgsFromRequest: defaultGetArgsFromRequest,
     httpMethod: 'post',
   });
@@ -57,7 +62,7 @@ Meteor.publish = function (name, handler, options) {
   oldPublish(name, handler, ddpOptions);
 
   _.defaults(httpOptions, {
-    url: SimpleRest._config.publicationUrlPrefix + name,
+    url: SimpleRest._config.urlTransform('publication', name),
     getArgsFromRequest: defaultGetArgsFromRequest,
     httpMethod: 'get',
   });

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -10,8 +10,8 @@ SimpleRest = {};
 //    objectIdCollections: ['widgets', 'doodles']
 SimpleRest._config = {
   urlTransform: (type, name) => {
-    if (type === 'method') return `${SimpleRest._config.methodUrlPrefix}${name}`,
-    if (type === 'publications') return `${SimpleRest._config.publicationUrlPrefix}${name}`,
+    if (type === 'method') return `${SimpleRest._config.methodUrlPrefix}${name}`;
+    if (type === 'publications') return `${SimpleRest._config.publicationUrlPrefix}${name}`;
     throw new Meteor.Error(404, `Unkown REST type: ${type} name: ${name}`);
   },
   methodUrlPrefix: 'methods/',

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -9,10 +9,10 @@ SimpleRest = {};
 // Also:
 //    objectIdCollections: ['widgets', 'doodles']
 SimpleRest._config = {
-  urlTransform: (type, name) => {
-    if (type === 'method') return `${SimpleRest._config.methodUrlPrefix}${name}`;
-    if (type === 'publications') return `${SimpleRest._config.publicationUrlPrefix}${name}`;
-    throw new Meteor.Error(404, `Unkown REST type: ${type} name: ${name}`);
+  urlTransform: function urlTransform(type, name) {
+    if (type === 'method') return SimpleRest._config.methodUrlPrefix + name;
+    if (type === 'publication') return SimpleRest._config.publicationUrlPrefix + name;
+    throw new Meteor.Error(404, 'Unkown REST type: ' + type + ' name: ' + name);
   },
   methodUrlPrefix: 'methods/',
   publicationUrlPrefix: 'publications/',

--- a/packages/rest/rest.js
+++ b/packages/rest/rest.js
@@ -8,7 +8,10 @@ SimpleRest = {};
 //
 // Also:
 //    objectIdCollections: ['widgets', 'doodles']
-SimpleRest._config = {};
+SimpleRest._config = {
+	methodUrlPrefix: 'methods/',
+	publicationUrlPrefix: 'publications/'
+};
 SimpleRest.configure = function (config) {
   return _.extend(SimpleRest._config, config);
 };
@@ -29,7 +32,7 @@ SimpleRest.setMethodOptions = function (name, options) {
   options = options || {};
 
   _.defaults(options, {
-    url: 'methods/' + name,
+    url: SimpleRest._config.methodUrlPrefix + name,
     getArgsFromRequest: defaultGetArgsFromRequest,
     httpMethod: 'post',
   });
@@ -54,7 +57,7 @@ Meteor.publish = function (name, handler, options) {
   oldPublish(name, handler, ddpOptions);
 
   _.defaults(httpOptions, {
-    url: 'publications/' + name,
+    url: SimpleRest._config.publicationUrlPrefix + name,
     getArgsFromRequest: defaultGetArgsFromRequest,
     httpMethod: 'get',
   });


### PR DESCRIPTION
re #106 - config for customizing paths

``` js
SimpleRest._config = {
  urlTransform: (type, name) => {
    if (type === 'method') return `${SimpleRest._config.methodUrlPrefix}${name}`,
    if (type === 'publications') return `${SimpleRest._config.publicationUrlPrefix}${name}`,
    throw new Meteor.Error(404, `Unkown REST type: ${type} name: ${name}`);
  },
  methodUrlPrefix: 'methods/',
  publicationUrlPrefix: 'publications/',
};
```
