### PR TITLE
Add package for auto CORS headers

### DIFF
--- a/packages/rest-cors/README.md
+++ b/packages/rest-cors/README.md
@@ -1,0 +1,53 @@
+# simple:rest-cors
+
+SimpleRestCors middleware for automatically allowing all CORS headers
+
+And responding with a request's `origin` as allowed.
+
+See [this fetch issue](https://github.com/whatwg/fetch/issues/251) for information on it,
+in short, allow `*` is not enough, you have to allow the specific origin.
+
+## Usage
+
+Automatically allow CORS for every request from all routes:
+
+```js
+JsonRoutes.Middleware.use(JsonRoutes.Middleware.handleCors);
+```
+
+Handle CORS from one route:
+
+```js
+JsonRoutes.Middleware.use(
+  '/handle-whatever',
+  JsonRoutes.Middleware.handleCors
+);
+```
+
+## Example
+
+```js
+JsonRoutes.Middleware.use(
+  '/handle-whatever',
+  RestMiddleware.handleCors
+);
+
+JsonRoutes.add('get', 'handle-whatever', function () {
+  JsonRoutes.sendResult(res, { data: { msg: 'ok' } });
+});
+```
+
+## Usage from client
+
+```
+fetch('http://localhost:3000/handle-whatever', {
+    method: 'post',
+    body: JSON.stringify({test:1})
+  }).then(function(response) {
+    return response.json();
+  }).then(function(data) {
+    console.log('Resp:', data);
+  }).catch(function(e) {
+    console.error(e);
+  });
+```

--- a/packages/rest-cors/json_cors_handler.js
+++ b/packages/rest-cors/json_cors_handler.js
@@ -1,0 +1,26 @@
+/**
+ * Handle CORS for any request
+ *
+ * @middleware
+ */
+// eslint-disable-next-line
+JsonRoutes.Middleware.handleCors = function (request, response, next) { // jshint ignore:line
+  const origin = (request.headers && request.headers.origin) || '*';
+  const newHeaders = {
+    CORSTEST: origin,
+    'Cache-Control': 'no-store',
+    Pragma: 'no-cache',
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'PUT, GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Requested-With',
+    'Access-Control-Allow-Credentials': 'true',
+  };
+  if (!response.headers) response.headers = {};
+  Object.keys(newHeaders).forEach(k => {
+    if (!response.headers[k]) {
+      response.headers[k] = newHeaders[k];
+      response.setHeader(k, newHeaders[k]);
+    }
+  });
+  next();
+};

--- a/packages/rest-cors/json_cors_handler_tests.js
+++ b/packages/rest-cors/json_cors_handler_tests.js
@@ -1,0 +1,24 @@
+if (Meteor.isServer) {
+  JsonRoutes.Middleware.use(
+    '/handle-whatever',
+    JsonRoutes.Middleware.handleCors
+  );
+
+  JsonRoutes.add('get', 'handle-whatever', function () {
+    JsonRoutes.sendResult(res, { data: { msg: 'ok' } });
+  });
+} else { // Meteor.isClient
+  testAsyncMulti('Middleware - CORS Handling - ' +
+    'handle standard CORS headers', [
+    function (test, waitFor) {
+      HTTP.get(Meteor.absoluteUrl('/handle-whatever'),
+        waitFor(function (err, resp) {
+          test.equal(resp.statusCode, 200);
+          test.equal(resp.headers['Access-Control-Allow-Origin'], origin);
+          test.equal(resp.headers['Access-Control-Allow-Methods'], 'GET, PUT, POST, DELETE, OPTIONS');
+          test.equal(resp.headers['Access-Control-Allow-Headers'], 'Origin, X-Requested-With, Content-Type, Accept, Authorization, X-Requested-With');
+          test.equal(resp.headers['Access-Control-Allow-Credentials'], 'true');
+        }));
+    },
+  ]);
+}

--- a/packages/rest-cors/package.js
+++ b/packages/rest-cors/package.js
@@ -1,0 +1,32 @@
+Package.describe({
+  name: 'simple:rest-cors',
+  version: '0.0.1',
+
+  // Brief, one-line summary of the package.
+  summary: 'middleware for handling standard CORS headers',
+
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/stubailo/meteor-rest',
+
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md',
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('1.0');
+  api.use('simple:json-routes@2.1.0');
+  api.addFiles('json_cors_handler.js', 'server');
+});
+
+Package.onTest(function (api) {
+  api.use([
+    'http',
+    'simple:json-routes@2.1.0',
+    'simple:rest-cors',
+    'test-helpers',
+    'tinytest',
+  ]);
+
+  api.addFiles('json_cors_handler_tests.js');
+});


### PR DESCRIPTION
This middleware will put in auto-headers on every response, to allow CORS.

is automatically replies by allowing the origin, if set, which gets around some browsers no longer accepting the "*" wildcard